### PR TITLE
Add Global Switch to Force Protocol

### DIFF
--- a/src/api/java/net/earthcomputer/multiconnect/api/EnumProtocol.java
+++ b/src/api/java/net/earthcomputer/multiconnect/api/EnumProtocol.java
@@ -2,48 +2,44 @@ package net.earthcomputer.multiconnect.api;
 
 public enum EnumProtocol {
 
-    AUTO(-1),
-    V1_15_1(Protocols.V1_15_1),
-    V1_15(Protocols.V1_15),
-    V1_14_4(Protocols.V1_14_4),
-    V1_14_3(Protocols.V1_14_3),
-    V1_14_2(Protocols.V1_14_2),
-    V1_14_1(Protocols.V1_14_1),
-    V1_14(Protocols.V1_14),
-    V1_13_2(Protocols.V1_13_2),
-    V1_13_1(Protocols.V1_13_1),
-    V1_13(Protocols.V1_13),
-    V1_12_2(Protocols.V1_12_2);
+    AUTO("Auto", -1),
+    V1_15_1("1.15.1", Protocols.V1_15_1),
+    V1_15("1.15", Protocols.V1_15),
+    V1_14_4("1.14.4", Protocols.V1_14_4),
+    V1_14_3("1.14.3", Protocols.V1_14_3),
+    V1_14_2("1.14.2", Protocols.V1_14_2),
+    V1_14_1("1.14.1", Protocols.V1_14_1),
+    V1_14("1.14", Protocols.V1_14),
+    V1_13_2("1.13.2", Protocols.V1_13_2),
+    V1_13_1("1.13.1", Protocols.V1_13_1),
+    V1_13("1.13", Protocols.V1_13),
+    V1_12_2("1.12.2", Protocols.V1_12_2);
 
-    private final int value;
+    private final int dataValue;
 
-    EnumProtocol(final int newValue) {
-        value = newValue;
+    private final String displayName;
+
+    EnumProtocol(final String name, final int value) {
+        dataValue = value;
+        displayName = name;
     }
 
-    public int getValue() { return value; }
+    public int getValue() { return dataValue; }
+
+    public String getDisplayName() { return displayName; }
 
     private static EnumProtocol[] dataValues = values();
 
     public EnumProtocol next() {
         EnumProtocol nextValue = AUTO;
 
-        for (EnumProtocol eachValue : dataValues) {
-            if (eachValue.value > value) {
-                nextValue = eachValue;
+        for (EnumProtocol protocolValue : dataValues) {
+            if (protocolValue.dataValue > dataValue) {
+                nextValue = protocolValue;
             }
         }
 
         return nextValue;
-    }
-
-    public static String getEnumNameForValue(int value) {
-        for(EnumProtocol eachValue : dataValues) {
-            if (eachValue.value == value) {
-                return eachValue.name();
-            }
-        }
-        return AUTO.name();
     }
 
 }

--- a/src/api/java/net/earthcomputer/multiconnect/api/EnumProtocol.java
+++ b/src/api/java/net/earthcomputer/multiconnect/api/EnumProtocol.java
@@ -3,17 +3,17 @@ package net.earthcomputer.multiconnect.api;
 public enum EnumProtocol {
 
     AUTO(-1),
-    V1_15_1(575),
-    V1_15(573),
-    V1_14_4(498),
-    V1_14_3(490),
-    V1_14_2(485),
-    V1_14_1(480),
-    V1_14(477),
-    V1_13_2(404),
-    V1_13_1(401),
-    V1_13(393),
-    V1_12_2(340);
+    V1_15_1(Protocols.V1_15_1),
+    V1_15(Protocols.V1_15),
+    V1_14_4(Protocols.V1_14_4),
+    V1_14_3(Protocols.V1_14_3),
+    V1_14_2(Protocols.V1_14_2),
+    V1_14_1(Protocols.V1_14_1),
+    V1_14(Protocols.V1_14),
+    V1_13_2(Protocols.V1_13_2),
+    V1_13_1(Protocols.V1_13_1),
+    V1_13(Protocols.V1_13),
+    V1_12_2(Protocols.V1_12_2);
 
     private final int value;
 
@@ -25,9 +25,16 @@ public enum EnumProtocol {
 
     private static EnumProtocol[] dataValues = values();
 
-    public EnumProtocol next()
-    {
-        return dataValues[(ordinal()+1) % dataValues.length];
+    public EnumProtocol next() {
+        EnumProtocol nextValue = AUTO;
+
+        for (EnumProtocol eachValue : dataValues) {
+            if (eachValue.value > value) {
+                nextValue = eachValue;
+            }
+        }
+
+        return nextValue;
     }
 
     public static String getEnumNameForValue(int value) {

--- a/src/api/java/net/earthcomputer/multiconnect/api/EnumProtocol.java
+++ b/src/api/java/net/earthcomputer/multiconnect/api/EnumProtocol.java
@@ -1,0 +1,42 @@
+package net.earthcomputer.multiconnect.api;
+
+public enum EnumProtocol {
+
+    AUTO(-1),
+    V1_15_1(575),
+    V1_15(573),
+    V1_14_4(498),
+    V1_14_3(490),
+    V1_14_2(485),
+    V1_14_1(480),
+    V1_14(477),
+    V1_13_2(404),
+    V1_13_1(401),
+    V1_13(393),
+    V1_12_2(340);
+
+    private final int value;
+
+    EnumProtocol(final int newValue) {
+        value = newValue;
+    }
+
+    public int getValue() { return value; }
+
+    private static EnumProtocol[] dataValues = values();
+
+    public EnumProtocol next()
+    {
+        return dataValues[(ordinal()+1) % dataValues.length];
+    }
+
+    public static String getEnumNameForValue(int value) {
+        for(EnumProtocol eachValue : dataValues) {
+            if (eachValue.value == value) {
+                return eachValue.name();
+            }
+        }
+        return AUTO.name();
+    }
+
+}

--- a/src/main/java/net/earthcomputer/multiconnect/impl/ConnectionInfo.java
+++ b/src/main/java/net/earthcomputer/multiconnect/impl/ConnectionInfo.java
@@ -1,5 +1,6 @@
 package net.earthcomputer.multiconnect.impl;
 
+import net.earthcomputer.multiconnect.api.EnumProtocol;
 import net.earthcomputer.multiconnect.protocols.AbstractProtocol;
 import net.earthcomputer.multiconnect.protocols.ProtocolRegistry;
 import net.minecraft.SharedConstants;
@@ -11,6 +12,7 @@ public class ConnectionInfo {
 
     public static String ip;
     public static int port = -1;
+    public static int forcedProtocolVersion = EnumProtocol.AUTO.getValue();
     public static int protocolVersion = SharedConstants.getGameVersion().getProtocolVersion();
     public static AbstractProtocol protocol = ProtocolRegistry.latest();
     public static boolean reloadingResources = false;

--- a/src/main/java/net/earthcomputer/multiconnect/impl/ConnectionInfo.java
+++ b/src/main/java/net/earthcomputer/multiconnect/impl/ConnectionInfo.java
@@ -12,7 +12,7 @@ public class ConnectionInfo {
 
     public static String ip;
     public static int port = -1;
-    public static int forcedProtocolVersion = EnumProtocol.AUTO.getValue();
+    public static EnumProtocol forcedProtocolVersion = EnumProtocol.AUTO;
     public static int protocolVersion = SharedConstants.getGameVersion().getProtocolVersion();
     public static AbstractProtocol protocol = ProtocolRegistry.latest();
     public static boolean reloadingResources = false;

--- a/src/main/java/net/earthcomputer/multiconnect/impl/IMixinScreen.java
+++ b/src/main/java/net/earthcomputer/multiconnect/impl/IMixinScreen.java
@@ -1,0 +1,10 @@
+package net.earthcomputer.multiconnect.impl;
+
+import net.minecraft.client.gui.widget.AbstractButtonWidget;
+
+public interface IMixinScreen {
+
+    void addGuiButtonToList(AbstractButtonWidget button);
+
+}
+

--- a/src/main/java/net/earthcomputer/multiconnect/mixin/MixinConnectScreen1.java
+++ b/src/main/java/net/earthcomputer/multiconnect/mixin/MixinConnectScreen1.java
@@ -1,5 +1,6 @@
 package net.earthcomputer.multiconnect.mixin;
 
+import net.earthcomputer.multiconnect.api.EnumProtocol;
 import net.earthcomputer.multiconnect.impl.ConnectionInfo;
 import net.earthcomputer.multiconnect.impl.GetProtocolPacketListener;
 import net.earthcomputer.multiconnect.impl.IConnectScreen;
@@ -68,6 +69,8 @@ public class MixinConnectScreen1 {
         connectScreen.multiconnect_setVersionRequestConnection(null);
 
         LogManager.getLogger("multiconnect").info("Discovered server protocol: " + ConnectionInfo.protocolVersion);
+        ConnectionInfo.protocolVersion = ConnectionInfo.forcedProtocolVersion != EnumProtocol.AUTO.getValue() ? ConnectionInfo.forcedProtocolVersion : ConnectionInfo.protocolVersion;
+        LogManager.getLogger("multiconnect").info("Using Protocol: " + ConnectionInfo.protocolVersion);
     }
 
     @Redirect(method = "run()V", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/ClientConnection;send(Lnet/minecraft/network/Packet;)V", ordinal = 0))

--- a/src/main/java/net/earthcomputer/multiconnect/mixin/MixinConnectScreen1.java
+++ b/src/main/java/net/earthcomputer/multiconnect/mixin/MixinConnectScreen1.java
@@ -69,7 +69,7 @@ public class MixinConnectScreen1 {
         connectScreen.multiconnect_setVersionRequestConnection(null);
 
         LogManager.getLogger("multiconnect").info("Discovered server protocol: " + ConnectionInfo.protocolVersion);
-        ConnectionInfo.protocolVersion = ConnectionInfo.forcedProtocolVersion != EnumProtocol.AUTO.getValue() ? ConnectionInfo.forcedProtocolVersion : ConnectionInfo.protocolVersion;
+        ConnectionInfo.protocolVersion = ConnectionInfo.forcedProtocolVersion != EnumProtocol.AUTO ? ConnectionInfo.forcedProtocolVersion.getValue() : ConnectionInfo.protocolVersion;
         LogManager.getLogger("multiconnect").info("Using Protocol: " + ConnectionInfo.protocolVersion);
     }
 

--- a/src/main/java/net/earthcomputer/multiconnect/mixin/MixinMultiplayerScreen.java
+++ b/src/main/java/net/earthcomputer/multiconnect/mixin/MixinMultiplayerScreen.java
@@ -19,8 +19,9 @@ public abstract class MixinMultiplayerScreen {
     public void createButtons(CallbackInfo ci) {
         IMixinScreen screen = (IMixinScreen) this;
 
-        protocolSelector = new ButtonWidget(5, 5, 70, 20, EnumProtocol.getEnumNameForValue(ConnectionInfo.forcedProtocolVersion).replace("_", ".").replace("V", ""), (buttonWidget_1) ->
-                ConnectionInfo.forcedProtocolVersion = EnumProtocol.valueOf(EnumProtocol.getEnumNameForValue(ConnectionInfo.forcedProtocolVersion)).next().getValue());
+        protocolSelector = new ButtonWidget(5, 5, 70, 20, ConnectionInfo.forcedProtocolVersion.getDisplayName(), (buttonWidget_1) ->
+                ConnectionInfo.forcedProtocolVersion = ConnectionInfo.forcedProtocolVersion.next()
+        );
 
         screen.addGuiButtonToList(protocolSelector);
     }
@@ -28,6 +29,6 @@ public abstract class MixinMultiplayerScreen {
     @Inject(method = "render", at = @At("RETURN"))
     public void drawScreen(int p_drawScreen_1_, int p_drawScreen_2_, float p_drawScreen_3_, CallbackInfo ci) {
         MinecraftClient.getInstance().textRenderer.drawWithShadow("<- Change Version", 80, 10, 0xFFFFFF);
-        protocolSelector.setMessage(EnumProtocol.getEnumNameForValue(ConnectionInfo.forcedProtocolVersion).replace("_", ".").replace("V", ""));
+        protocolSelector.setMessage(ConnectionInfo.forcedProtocolVersion.getDisplayName());
     }
 }

--- a/src/main/java/net/earthcomputer/multiconnect/mixin/MixinMultiplayerScreen.java
+++ b/src/main/java/net/earthcomputer/multiconnect/mixin/MixinMultiplayerScreen.java
@@ -19,7 +19,7 @@ public abstract class MixinMultiplayerScreen {
     public void createButtons(CallbackInfo ci) {
         IMixinScreen screen = (IMixinScreen) this;
 
-        protocolSelector = new ButtonWidget(5, 5, 70, 20, EnumProtocol.getEnumNameForValue(ConnectionInfo.forcedProtocolVersion), (buttonWidget_1) ->
+        protocolSelector = new ButtonWidget(5, 5, 70, 20, EnumProtocol.getEnumNameForValue(ConnectionInfo.forcedProtocolVersion).replace("_", ".").replace("V", ""), (buttonWidget_1) ->
                 ConnectionInfo.forcedProtocolVersion = EnumProtocol.valueOf(EnumProtocol.getEnumNameForValue(ConnectionInfo.forcedProtocolVersion)).next().getValue());
 
         screen.addGuiButtonToList(protocolSelector);
@@ -28,6 +28,6 @@ public abstract class MixinMultiplayerScreen {
     @Inject(method = "render", at = @At("RETURN"))
     public void drawScreen(int p_drawScreen_1_, int p_drawScreen_2_, float p_drawScreen_3_, CallbackInfo ci) {
         MinecraftClient.getInstance().textRenderer.drawWithShadow("<- Change Version", 80, 10, 0xFFFFFF);
-        protocolSelector.setMessage(EnumProtocol.getEnumNameForValue(ConnectionInfo.forcedProtocolVersion));
+        protocolSelector.setMessage(EnumProtocol.getEnumNameForValue(ConnectionInfo.forcedProtocolVersion).replace("_", ".").replace("V", ""));
     }
 }

--- a/src/main/java/net/earthcomputer/multiconnect/mixin/MixinMultiplayerScreen.java
+++ b/src/main/java/net/earthcomputer/multiconnect/mixin/MixinMultiplayerScreen.java
@@ -1,0 +1,33 @@
+package net.earthcomputer.multiconnect.mixin;
+
+import net.earthcomputer.multiconnect.api.EnumProtocol;
+import net.earthcomputer.multiconnect.impl.ConnectionInfo;
+import net.earthcomputer.multiconnect.impl.IMixinScreen;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.multiplayer.MultiplayerScreen;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MultiplayerScreen.class)
+public abstract class MixinMultiplayerScreen {
+    private ButtonWidget protocolSelector;
+
+    @Inject(method = "init", at = @At("RETURN"))
+    public void createButtons(CallbackInfo ci) {
+        IMixinScreen screen = (IMixinScreen) this;
+
+        protocolSelector = new ButtonWidget(5, 5, 70, 20, EnumProtocol.getEnumNameForValue(ConnectionInfo.forcedProtocolVersion), (buttonWidget_1) ->
+                ConnectionInfo.forcedProtocolVersion = EnumProtocol.valueOf(EnumProtocol.getEnumNameForValue(ConnectionInfo.forcedProtocolVersion)).next().getValue());
+
+        screen.addGuiButtonToList(protocolSelector);
+    }
+
+    @Inject(method = "render", at = @At("RETURN"))
+    public void drawScreen(int p_drawScreen_1_, int p_drawScreen_2_, float p_drawScreen_3_, CallbackInfo ci) {
+        MinecraftClient.getInstance().textRenderer.drawWithShadow("<- Change Version", 80, 10, 0xFFFFFF);
+        protocolSelector.setMessage(EnumProtocol.getEnumNameForValue(ConnectionInfo.forcedProtocolVersion));
+    }
+}

--- a/src/main/java/net/earthcomputer/multiconnect/mixin/MixinScreen.java
+++ b/src/main/java/net/earthcomputer/multiconnect/mixin/MixinScreen.java
@@ -1,0 +1,21 @@
+package net.earthcomputer.multiconnect.mixin;
+
+import net.earthcomputer.multiconnect.impl.IMixinScreen;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.widget.AbstractButtonWidget;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(Screen.class)
+public abstract class MixinScreen implements IMixinScreen {
+
+    @Shadow
+    protected abstract <T extends AbstractButtonWidget> T addButton(T p_addButton_1_);
+
+    @Override
+    public void addGuiButtonToList(AbstractButtonWidget button) {
+        addButton(button);
+    }
+
+}
+

--- a/src/main/resources/multiconnect.mixins.json
+++ b/src/main/resources/multiconnect.mixins.json
@@ -9,6 +9,8 @@
     "MixinConnectScreen1",
     "MixinHandshakePacket",
     "MixinMinecraftClient",
+    "MixinScreen",
+    "MixinMultiplayerScreen",
     "MixinServerListIcon",
     "MixinNetworkState",
     "MixinClientConnection",


### PR DESCRIPTION
Notes:
This PR adds a switch in the MultiplayerScreen, allowing the user to cycle through available protocols, in case the server doesn't connect using the automatic implementation (This is the case for proxy servers like BungeeCord).

Closes #11 