### PR TITLE
[Change] Re-Add Global Protocol Switch

### DIFF
--- a/src/main/java/net/earthcomputer/multiconnect/impl/ConnectionInfo.java
+++ b/src/main/java/net/earthcomputer/multiconnect/impl/ConnectionInfo.java
@@ -11,6 +11,7 @@ public class ConnectionInfo {
 
     public static String ip;
     public static int port = -1;
+    public static ConnectionMode globalForcedProtocolVersion = ConnectionMode.AUTO;
     public static int protocolVersion = SharedConstants.getGameVersion().getProtocolVersion();
     public static AbstractProtocol protocol = ProtocolRegistry.latest();
     public static boolean reloadingResources = false;

--- a/src/main/java/net/earthcomputer/multiconnect/mixin/MixinConnectScreen1.java
+++ b/src/main/java/net/earthcomputer/multiconnect/mixin/MixinConnectScreen1.java
@@ -41,6 +41,8 @@ public class MixinConnectScreen1 {
             address = ConnectionInfo.ip + ":" + ConnectionInfo.port;
         }
         int forcedVersion = ServersExt.getInstance().getForcedProtocol(address);
+        forcedVersion = forcedVersion == ConnectionMode.AUTO.getValue() ? ConnectionInfo.globalForcedProtocolVersion.getValue() : forcedVersion;
+
         if (forcedVersion != ConnectionMode.AUTO.getValue()) {
             ConnectionInfo.protocolVersion = forcedVersion;
             LogManager.getLogger("multiconnect").info("Protocol version forced to " + ConnectionInfo.protocolVersion + " (" + ConnectionMode.byValue(forcedVersion).getName() + ")");

--- a/src/main/java/net/earthcomputer/multiconnect/mixin/MixinMultiplayerScreen.java
+++ b/src/main/java/net/earthcomputer/multiconnect/mixin/MixinMultiplayerScreen.java
@@ -1,0 +1,38 @@
+package net.earthcomputer.multiconnect.mixin;
+
+import net.earthcomputer.multiconnect.impl.ConnectionInfo;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.multiplayer.MultiplayerScreen;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.client.resource.language.I18n;
+import net.minecraft.text.Text;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MultiplayerScreen.class)
+public class MixinMultiplayerScreen extends Screen {
+    @Unique private ButtonWidget protocolSelector;
+
+    protected MixinMultiplayerScreen(Text title) {
+        super(title);
+    }
+
+    @Inject(method = "init", at = @At("RETURN"))
+    public void createButtons(CallbackInfo ci) {
+        protocolSelector = new ButtonWidget(width - 80, 5, 70, 20, ConnectionInfo.globalForcedProtocolVersion.getName(), (buttonWidget_1) ->
+                ConnectionInfo.globalForcedProtocolVersion = ConnectionInfo.globalForcedProtocolVersion.next()
+        );
+
+        addButton(protocolSelector);
+    }
+
+    @Inject(method = "render", at = @At("RETURN"))
+    public void drawScreen(int p_drawScreen_1_, int p_drawScreen_2_, float p_drawScreen_3_, CallbackInfo ci) {
+        MinecraftClient.getInstance().textRenderer.drawWithShadow(I18n.translate("multiconnect.changeForcedProtocol") + " ->", width - 85 - MinecraftClient.getInstance().textRenderer.getStringWidth(I18n.translate("multiconnect.changeForcedProtocol") + " ->"), 11, 0xFFFFFF);
+        protocolSelector.setMessage(ConnectionInfo.globalForcedProtocolVersion.getName());
+    }
+}

--- a/src/main/resources/multiconnect.mixins.json
+++ b/src/main/resources/multiconnect.mixins.json
@@ -35,7 +35,7 @@
     "MixinSplashScreen",
     "MixinTranslationStorage",
     "MixinWorldChunk",
-
+    "MixinMultiplayerScreen",
     "HandshakePacketAccessor",
     "SpawnEggItemAccessor",
     "TrackedDataAccessor",


### PR DESCRIPTION
Notes:
This PR Re-Adds the Global Protocol Switch, with differences being it is now used as a fallback, if the Per-Server setting cannot be found or is AUTO.

In addition, It also better formats the switch to look nicer and more obvious to end-users

https://cdn.discordapp.com/attachments/658063802780221452/665996772082188325/unknown.png

![image](https://user-images.githubusercontent.com/16328918/72224280-4def6300-353e-11ea-8d2a-de8370117bb1.png)
