### PR TITLE
[Fix] Fix Language Manager Asset IDs

### DIFF
--- a/src/api/java/net/earthcomputer/multiconnect/api/EnumProtocol.java
+++ b/src/api/java/net/earthcomputer/multiconnect/api/EnumProtocol.java
@@ -29,9 +29,18 @@ public enum EnumProtocol {
 
     private final String name;
 
+    private final String assetID;
+
     EnumProtocol(final String name, final int value) {
         this.value = value;
         this.name = name;
+        this.assetID = name;
+    }
+
+    EnumProtocol(final String name, final String assetID, final int value) {
+        this.value = value;
+        this.name = name;
+        this.assetID = assetID;
     }
 
     public int getValue() {
@@ -40,6 +49,10 @@ public enum EnumProtocol {
 
     public String getName() {
         return name;
+    }
+
+    public String getAssetID() {
+        return assetID;
     }
 
     private static final EnumProtocol[] VALUES = values();

--- a/src/main/java/net/earthcomputer/multiconnect/impl/OldLanguageManager.java
+++ b/src/main/java/net/earthcomputer/multiconnect/impl/OldLanguageManager.java
@@ -51,8 +51,8 @@ public class OldLanguageManager {
         if (ConnectionInfo.protocol == ProtocolRegistry.latest())
             return;
 
-        String currentVersion = EnumProtocol.byValue(ConnectionInfo.protocolVersion).getName();
-        String latestVersion = EnumProtocol.byValue(SharedConstants.getGameVersion().getProtocolVersion()).getName();
+        String currentVersion = EnumProtocol.byValue(ConnectionInfo.protocolVersion).getAssetID();
+        String latestVersion = EnumProtocol.byValue(SharedConstants.getGameVersion().getProtocolVersion()).getAssetID();
 
         Map<String, String> currentNative = getTranslations(currentVersion, nativeLang);
         Map<String, String> currentFallback = getTranslations(currentVersion, "en_us");


### PR DESCRIPTION
Pre-Releases or Experimental Updates may not use the appropriate Asset ID, which can now be set as an Enum Property