### PR TITLE
Made adjustments to swim speed on surface

### DIFF
--- a/src/main/java/net/earthcomputer/multiconnect/protocols/v1_12_2/mixin/MixinEntity.java
+++ b/src/main/java/net/earthcomputer/multiconnect/protocols/v1_12_2/mixin/MixinEntity.java
@@ -5,6 +5,7 @@ import net.earthcomputer.multiconnect.impl.ConnectionInfo;
 import net.minecraft.entity.Entity;
 import net.minecraft.fluid.Fluid;
 import net.minecraft.fluid.FluidState;
+import net.minecraft.tag.FluidTags;
 import net.minecraft.tag.Tag;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Box;
@@ -29,6 +30,14 @@ public abstract class MixinEntity {
     @Shadow public abstract void setVelocity(Vec3d velocity);
 
     @Shadow public abstract Vec3d getVelocity();
+
+    @Shadow public abstract double getWaterHeight();
+
+    @Shadow public abstract boolean isTouchingWater();
+
+    @Shadow public abstract boolean isSubmergedInWater();
+
+    @Shadow public abstract boolean isSubmergedIn(Tag<Fluid> fluidTag, boolean requireLoadedChunk);
 
     @Inject(method = "setSwimming", at = @At("HEAD"), cancellable = true)
     private void onSetSwimming(boolean swimming, CallbackInfo ci) {
@@ -83,6 +92,13 @@ public abstract class MixinEntity {
 
         this.waterHeight = waterHeight;
         ci.setReturnValue(foundFluid);
+    }
+
+    @Inject(method = "isTouchingWater", at = @At(value = "RETURN"), cancellable = true)
+    private void correctStatus(CallbackInfoReturnable<Boolean> cir) {
+        if (cir.getReturnValueZ() && !isSubmergedIn(FluidTags.WATER, true) && getWaterHeight() < 0.28888931871D) {
+            cir.setReturnValue(false);
+        }
     }
 
 }

--- a/src/main/java/net/earthcomputer/multiconnect/protocols/v1_12_2/mixin/MixinEntity.java
+++ b/src/main/java/net/earthcomputer/multiconnect/protocols/v1_12_2/mixin/MixinEntity.java
@@ -5,7 +5,6 @@ import net.earthcomputer.multiconnect.impl.ConnectionInfo;
 import net.minecraft.entity.Entity;
 import net.minecraft.fluid.Fluid;
 import net.minecraft.fluid.FluidState;
-import net.minecraft.tag.FluidTags;
 import net.minecraft.tag.Tag;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Box;
@@ -30,14 +29,6 @@ public abstract class MixinEntity {
     @Shadow public abstract void setVelocity(Vec3d velocity);
 
     @Shadow public abstract Vec3d getVelocity();
-
-    @Shadow public abstract double getWaterHeight();
-
-    @Shadow public abstract boolean isTouchingWater();
-
-    @Shadow public abstract boolean isSubmergedInWater();
-
-    @Shadow public abstract boolean isSubmergedIn(Tag<Fluid> fluidTag, boolean requireLoadedChunk);
 
     @Inject(method = "setSwimming", at = @At("HEAD"), cancellable = true)
     private void onSetSwimming(boolean swimming, CallbackInfo ci) {
@@ -92,13 +83,6 @@ public abstract class MixinEntity {
 
         this.waterHeight = waterHeight;
         ci.setReturnValue(foundFluid);
-    }
-
-    @Inject(method = "isTouchingWater", at = @At(value = "RETURN"), cancellable = true)
-    private void correctStatus(CallbackInfoReturnable<Boolean> cir) {
-        if (cir.getReturnValueZ() && !isSubmergedIn(FluidTags.WATER, true) && getWaterHeight() < 0.28888931871D) {
-            cir.setReturnValue(false);
-        }
     }
 
 }

--- a/src/main/java/net/earthcomputer/multiconnect/protocols/v1_12_2/mixin/MixinEntity.java
+++ b/src/main/java/net/earthcomputer/multiconnect/protocols/v1_12_2/mixin/MixinEntity.java
@@ -92,9 +92,8 @@ public abstract class MixinEntity {
 
     @Inject(method = "isTouchingWater", at = @At(value = "RETURN"), cancellable = true)
     private void correctStatus(CallbackInfoReturnable<Boolean> cir) {
-        if (cir.getReturnValueZ() && !isSubmergedIn(FluidTags.WATER, true) && getWaterHeight() < 0.28888931871D) {
+        if (ConnectionInfo.protocolVersion <= Protocols.V1_12_2 && cir.getReturnValueZ() && !isSubmergedIn(FluidTags.WATER, true) && getWaterHeight() < 0.28888931871D) {
             cir.setReturnValue(false);
         }
     }
-
 }

--- a/src/main/java/net/earthcomputer/multiconnect/protocols/v1_12_2/mixin/MixinEntity.java
+++ b/src/main/java/net/earthcomputer/multiconnect/protocols/v1_12_2/mixin/MixinEntity.java
@@ -5,6 +5,7 @@ import net.earthcomputer.multiconnect.impl.ConnectionInfo;
 import net.minecraft.entity.Entity;
 import net.minecraft.fluid.Fluid;
 import net.minecraft.fluid.FluidState;
+import net.minecraft.tag.FluidTags;
 import net.minecraft.tag.Tag;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Box;
@@ -29,6 +30,10 @@ public abstract class MixinEntity {
     @Shadow public abstract void setVelocity(Vec3d velocity);
 
     @Shadow public abstract Vec3d getVelocity();
+
+    @Shadow public abstract double getWaterHeight();
+
+    @Shadow public abstract boolean isSubmergedIn(Tag<Fluid> fluidTag, boolean requireLoadedChunk);
 
     @Inject(method = "setSwimming", at = @At("HEAD"), cancellable = true)
     private void onSetSwimming(boolean swimming, CallbackInfo ci) {
@@ -83,6 +88,13 @@ public abstract class MixinEntity {
 
         this.waterHeight = waterHeight;
         ci.setReturnValue(foundFluid);
+    }
+
+    @Inject(method = "isTouchingWater", at = @At(value = "RETURN"), cancellable = true)
+    private void correctStatus(CallbackInfoReturnable<Boolean> cir) {
+        if (cir.getReturnValueZ() && !isSubmergedIn(FluidTags.WATER, true) && getWaterHeight() < 0.28888931871D) {
+            cir.setReturnValue(false);
+        }
     }
 
 }


### PR DESCRIPTION
1.15 client slows down the swim speed on surface for roughly 0.2 blocks too high. (so if you are in that 0.2 block gap you are slower than you should be).
This should fix that.

Also I this is my first pull request so let's hope all goes fine with this.