### PR TITLE
Fix hoe tool speed on 1.15.2 and below

### DIFF
--- a/src/main/java/net/earthcomputer/multiconnect/protocols/v1_15_2/mixin/MixinMiningToolItem.java
+++ b/src/main/java/net/earthcomputer/multiconnect/protocols/v1_15_2/mixin/MixinMiningToolItem.java
@@ -1,0 +1,24 @@
+package net.earthcomputer.multiconnect.protocols.v1_15_2.mixin;
+
+import net.earthcomputer.multiconnect.api.Protocols;
+import net.earthcomputer.multiconnect.impl.ConnectionInfo;
+import net.minecraft.block.BlockState;
+import net.minecraft.item.HoeItem;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.MiningToolItem;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+
+@Mixin(MiningToolItem.class)
+public class MixinMiningToolItem {
+
+    @Inject(at = @At("RETURN"), method="getMiningSpeedMultiplier", cancellable = true)
+    public void changeHoeEffectiveBlocks(ItemStack stack, BlockState state, CallbackInfoReturnable<Float> cir) {
+        if (ConnectionInfo.protocolVersion <= Protocols.V1_15_2 && (Object)this instanceof HoeItem) {
+            cir.setReturnValue(1.0F);
+        }
+    }
+}

--- a/src/main/java/net/earthcomputer/multiconnect/protocols/v1_15_2/mixin/MixinMiningToolItem.java
+++ b/src/main/java/net/earthcomputer/multiconnect/protocols/v1_15_2/mixin/MixinMiningToolItem.java
@@ -15,7 +15,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(MiningToolItem.class)
 public class MixinMiningToolItem {
 
-    @Inject(at = @At("RETURN"), method="getMiningSpeedMultiplier", cancellable = true)
+    @Inject(method="getMiningSpeedMultiplier", at = @At("RETURN"), cancellable = true)
     public void changeHoeEffectiveBlocks(ItemStack stack, BlockState state, CallbackInfoReturnable<Float> cir) {
         if (ConnectionInfo.protocolVersion <= Protocols.V1_15_2 && (Object)this instanceof HoeItem) {
             cir.setReturnValue(1.0F);

--- a/src/main/resources/multiconnect.1_15_2.mixins.json
+++ b/src/main/resources/multiconnect.1_15_2.mixins.json
@@ -3,6 +3,7 @@
   "package": "net.earthcomputer.multiconnect.protocols.v1_15_2.mixin",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
+    "MixinMiningToolItem",
     "MixinWallBlock",
     "TameableEntityAccessor",
     "WolfEntityAccessor"


### PR DESCRIPTION
Hoes were made to actually be able to mine some blocks faster in 1.16.
This fixes that for older versions.