### PR TITLE
Adjust movement zero condition for 1.8

### DIFF
--- a/src/main/java/net/earthcomputer/multiconnect/protocols/v1_8/mixin/MixinLivingEntity.java
+++ b/src/main/java/net/earthcomputer/multiconnect/protocols/v1_8/mixin/MixinLivingEntity.java
@@ -1,0 +1,19 @@
+package net.earthcomputer.multiconnect.protocols.v1_8.mixin;
+
+import net.earthcomputer.multiconnect.api.Protocols;
+import net.earthcomputer.multiconnect.impl.ConnectionInfo;
+import net.minecraft.entity.LivingEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(LivingEntity.class)
+public class MixinLivingEntity {
+
+    @ModifyConstant(method = "tickMovement", constant = @Constant(doubleValue = 0.003D))
+    public double modifyVelocityZero(final double constant) {
+        if (ConnectionInfo.protocolVersion <= Protocols.V1_8) return 0.005D;
+        return constant;
+    }
+
+}

--- a/src/main/resources/multiconnect.1_8.mixins.json
+++ b/src/main/resources/multiconnect.1_8.mixins.json
@@ -26,6 +26,7 @@
     "MixinEntityRenderDispatcher",
     "MixinHeldItemRenderer",
     "MixinItemStack",
+    "MixinLivingEntity",
     "MixinMinecraftClient",
     "MixinPlayerEntity",
     "MixinPlayerInventory",


### PR DESCRIPTION
Fixes some of the 1.8 movement differences.
This fixes issues on an anticheat testserver (cac.dodo1213.de) where the player can't jump without being flagged.