### PR TITLE
Remove ModMenu stuff

### DIFF
--- a/src/api/resources/fabric.mod.json
+++ b/src/api/resources/fabric.mod.json
@@ -24,5 +24,11 @@
 
   "depends": {
     "fabricloader": ">=0.4.0"
+  },
+  
+  "custom": {
+    "modmenu": {
+      "badges": [ "library" ]
+    }
   }
 }

--- a/src/api/resources/fabric.mod.json
+++ b/src/api/resources/fabric.mod.json
@@ -25,7 +25,7 @@
   "depends": {
     "fabricloader": ">=0.4.0"
   },
-  
+
   "custom": {
     "modmenu": {
       "badges": [ "library" ]

--- a/src/api/resources/fabric.mod.json
+++ b/src/api/resources/fabric.mod.json
@@ -24,10 +24,5 @@
 
   "depends": {
     "fabricloader": ">=0.4.0"
-  },
-
-  "custom": {
-    "modmenu:api": true,
-    "modmenu:clientsideOnly": true
   }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -43,7 +43,6 @@
   },
 
   "custom": {
-    "modmenu:clientsideOnly": true,
     "lithium:options": {
       "mixin.entity.data_tracker": false
     }


### PR DESCRIPTION
Both `modmenu:clientsideOnly` and `modmenu:api` are deprecated and unneeded, and also warn in logs that they will be removed in 1.18 snapshots and that we should tell the mod authors to support the new API.