### PR TITLE
fix InvalidIdentifierException due to spawn eggs

### DIFF
--- a/src/main/java/net/earthcomputer/multiconnect/protocols/v1_12_2/Items_1_12_2.java
+++ b/src/main/java/net/earthcomputer/multiconnect/protocols/v1_12_2/Items_1_12_2.java
@@ -59,12 +59,15 @@ public class Items_1_12_2 {
             CompoundTag entityTag = stack.getSubTag("EntityTag");
             if (entityTag != null) {
                 String entityId = entityTag.getString("id");
-                EntityType<?> entityType = Registry.ENTITY_TYPE.get(new Identifier(entityId));
-                newItem = SpawnEggItem.forEntity(entityType);
-                if (newItem != null) {
-                    ItemStack newStack = new ItemStack(newItem, stack.getCount());
-                    newStack.setTag(stack.getTag());
-                    stack = newStack;
+                Identifier identifier = Identifier.tryParse(entityId);
+                if(identifier != null) {
+                    EntityType<?> entityType = Registry.ENTITY_TYPE.get(identifier);
+                    newItem = SpawnEggItem.forEntity(entityType);
+                    if (newItem != null) {
+                        ItemStack newStack = new ItemStack(newItem, stack.getCount());
+                        newStack.setTag(stack.getTag());
+                        stack = newStack;
+                    }
                 }
             }
         }


### PR DESCRIPTION
On Cubecraft for some reason it throws an InvalidIdentifierException due to spawn eggs. This fixes the problem.

````
[21:07:19] [Netty Epoll Client IO #7/ERROR] (multiconnect) Unexpectedly disconnected from server!
 io.netty.handler.codec.DecoderException: net.minecraft.util.InvalidIdentifierException: Non [a-z0-9/._-] character in path of location: minecraft:Villager
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:459) ~[netty-all-4.1.25.Final.jar:4.1.25.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:265) ~[netty-all-4.1.25.Final.jar:4.1.25.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362) [netty-all-4.1.25.Final.jar:4.1.25.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348) [netty-all-4.1.25.Final.jar:4.1.25.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340) [netty-all-4.1.25.Final.jar:4.1.25.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:310) [netty-all-4.1.25.Final.jar:4.1.25.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:284) [netty-all-4.1.25.Final.jar:4.1.25.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362) [netty-all-4.1.25.Final.jar:4.1.25.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348) [netty-all-4.1.25.Final.jar:4.1.25.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340) [netty-all-4.1.25.Final.jar:4.1.25.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:310) [netty-all-4.1.25.Final.jar:4.1.25.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:297) [netty-all-4.1.25.Final.jar:4.1.25.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:413) [netty-all-4.1.25.Final.jar:4.1.25.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:265) [netty-all-4.1.25.Final.jar:4.1.25.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362) [netty-all-4.1.25.Final.jar:4.1.25.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348) [netty-all-4.1.25.Final.jar:4.1.25.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340) [netty-all-4.1.25.Final.jar:4.1.25.Final]
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:102) [netty-all-4.1.25.Final.jar:4.1.25.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362) [netty-all-4.1.25.Final.jar:4.1.25.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348) [netty-all-4.1.25.Final.jar:4.1.25.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340) [netty-all-4.1.25.Final.jar:4.1.25.Final]
	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286) [netty-all-4.1.25.Final.jar:4.1.25.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362) [netty-all-4.1.25.Final.jar:4.1.25.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348) [netty-all-4.1.25.Final.jar:4.1.25.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340) [netty-all-4.1.25.Final.jar:4.1.25.Final]
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1434) [netty-all-4.1.25.Final.jar:4.1.25.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362) [netty-all-4.1.25.Final.jar:4.1.25.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348) [netty-all-4.1.25.Final.jar:4.1.25.Final]
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:965) [netty-all-4.1.25.Final.jar:4.1.25.Final]
	at io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:808) [netty-all-4.1.25.Final.jar:4.1.25.Final]
	at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:408) [netty-all-4.1.25.Final.jar:4.1.25.Final]
	at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:308) [netty-all-4.1.25.Final.jar:4.1.25.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:884) [netty-all-4.1.25.Final.jar:4.1.25.Final]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_272]
Caused by: net.minecraft.util.InvalidIdentifierException: Non [a-z0-9/._-] character in path of location: minecraft:Villager
	at net.minecraft.util.Identifier.<init>(Identifier.java:36) ~[minecraft-1.16.5-mapped-net.fabricmc.yarn-1.16.5+build.1-v2.jar:?]
	at net.minecraft.util.Identifier.<init>(Identifier.java:47) ~[minecraft-1.16.5-mapped-net.fabricmc.yarn-1.16.5+build.1-v2.jar:?]
	at net.earthcomputer.multiconnect.protocols.v1_12_2.Items_1_12_2.oldItemStackToNew(Items_1_12_2.java:62) ~[multiconnect-slim-1.3.37.jar:?]
	at net.earthcomputer.multiconnect.protocols.v1_12_2.Protocol_1_12_2$1.translate(Protocol_1_12_2.java:453) ~[multiconnect-slim-1.3.37.jar:?]
	at net.earthcomputer.multiconnect.protocols.v1_12_2.Protocol_1_12_2$1.translate(Protocol_1_12_2.java:422) ~[multiconnect-slim-1.3.37.jar:?]
	at net.earthcomputer.multiconnect.transformer.TransformerByteBuf.read(TransformerByteBuf.java:173) ~[multiconnect-slim-1.3.37.jar:?]
	at net.earthcomputer.multiconnect.transformer.TransformerByteBuf.read(TransformerByteBuf.java:123) ~[multiconnect-slim-1.3.37.jar:?]
	at net.earthcomputer.multiconnect.transformer.TransformerByteBuf.readItemStack(TransformerByteBuf.java:708) ~[multiconnect-slim-1.3.37.jar:?]
	at net.minecraft.network.packet.s2c.play.ScreenHandlerSlotUpdateS2CPacket.read(ScreenHandlerSlotUpdateS2CPacket.java:34) ~[minecraft-1.16.5-mapped-net.fabricmc.yarn-1.16.5+build.1-v2.jar:?]
	at net.minecraft.network.DecoderHandler.decode(DecoderHandler.java:30) ~[minecraft-1.16.5-mapped-net.fabricmc.yarn-1.16.5+build.1-v2.jar:?]
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:489) ~[netty-all-4.1.25.Final.jar:4.1.25.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:428) ~[netty-all-4.1.25.Final.jar:4.1.25.Final]
	... 33 more
[21:07:19] [main/INFO] (ChunkBuilder) Stopping worker threads
`