### PR TITLE
Fix attack and swing packet order on 1.8

### DIFF
--- a/src/main/java/net/earthcomputer/multiconnect/protocols/v1_8/mixin/MixinMinecraftClient.java
+++ b/src/main/java/net/earthcomputer/multiconnect/protocols/v1_8/mixin/MixinMinecraftClient.java
@@ -4,18 +4,28 @@ import net.earthcomputer.multiconnect.api.Protocols;
 import net.earthcomputer.multiconnect.impl.ConnectionInfo;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.client.network.ClientPlayerInteractionManager;
 import net.minecraft.client.render.item.HeldItemRenderer;
 import net.minecraft.item.SwordItem;
 import net.minecraft.util.Hand;
+import net.minecraft.util.hit.EntityHitResult;
+import net.minecraft.util.hit.HitResult;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.Slice;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(MinecraftClient.class)
 public class MixinMinecraftClient {
     @Shadow public ClientPlayerEntity player;
+
+    @Shadow @Nullable public ClientPlayerInteractionManager interactionManager;
+
+    @Shadow @Nullable public HitResult crosshairTarget;
 
     @Redirect(method = "doItemUse",
             slice = @Slice(from = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerInteractionManager;interactItem(Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/world/World;Lnet/minecraft/util/Hand;)Lnet/minecraft/util/ActionResult;")),
@@ -23,6 +33,15 @@ public class MixinMinecraftClient {
     private void redirectResetEquipProgress(HeldItemRenderer heldItemRenderer, Hand hand) {
         if (ConnectionInfo.protocolVersion > Protocols.V1_8 || !(player.getStackInHand(hand).getItem() instanceof SwordItem)) {
             heldItemRenderer.resetEquipProgress(hand);
+        }
+    }
+
+    @Inject(method = "doAttack", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerInteractionManager;attackEntity(Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/entity/Entity;)V"), cancellable = true)
+    private void multiconnect1_8_FixAttackPacketOrder(CallbackInfo ci) {
+        if (ConnectionInfo.protocolVersion <= Protocols.V1_8) {
+            this.player.swingHand(Hand.MAIN_HAND);
+            this.interactionManager.attackEntity(this.player, ((EntityHitResult)this.crosshairTarget).getEntity());
+            ci.cancel();
         }
     }
 }


### PR DESCRIPTION
The packet order being wrong has been triggering anticheats when attacking entities.