### PR TITLE
Fix bulk chunk data packet reading on 1.8

### DIFF
--- a/src/main/java/net/earthcomputer/multiconnect/protocols/v1_8/BulkChunkDataS2CPacket_1_8.java
+++ b/src/main/java/net/earthcomputer/multiconnect/protocols/v1_8/BulkChunkDataS2CPacket_1_8.java
@@ -20,7 +20,7 @@ public class BulkChunkDataS2CPacket_1_8 implements Packet<ClientPlayPacketListen
             Entry entry = entries[i] = new Entry();
             entry.x = buf.readInt();
             entry.z = buf.readInt();
-            entry.verticalStripBitmask = buf.readShort();
+            entry.verticalStripBitmask = buf.readUnsignedShort();
             entry.data = new byte[calcDataSize(Integer.bitCount(entry.verticalStripBitmask), hasSkyLight)];
         }
         for (int i = 0; i < numChunks; i++) {


### PR DESCRIPTION
Primary Bit Mask was being read as a normal short but it is actually an 
unsigned short. Fixes #200 