### PR TITLE
Fix lag back with anticheats in minecraft 1.17

### DIFF
--- a/src/main/java/net/earthcomputer/multiconnect/protocols/v1_17/mixin/MixinClientPlayerInteractionManager.java
+++ b/src/main/java/net/earthcomputer/multiconnect/protocols/v1_17/mixin/MixinClientPlayerInteractionManager.java
@@ -1,0 +1,24 @@
+package net.earthcomputer.multiconnect.protocols.v1_17.mixin;
+
+import net.earthcomputer.multiconnect.api.Protocols;
+import net.earthcomputer.multiconnect.impl.ConnectionInfo;
+import net.minecraft.client.network.ClientPlayNetworkHandler;
+import net.minecraft.client.network.ClientPlayerInteractionManager;
+import net.minecraft.network.Packet;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.Slice;
+
+@Mixin(value = ClientPlayerInteractionManager.class, priority = 0)
+public class MixinClientPlayerInteractionManager {
+
+    @Redirect(method = "interactItem", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayNetworkHandler;sendPacket(Lnet/minecraft/network/Packet;)V", ordinal = 0),
+            slice = @Slice(from = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerInteractionManager;syncSelectedSlot()V"), to = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayNetworkHandler;sendPacket(Lnet/minecraft/network/Packet;)V", ordinal = 1)))
+    private void redirectPlayerPosPacket(ClientPlayNetworkHandler clientPlayNetworkHandler, Packet<?> packet) {
+        if(ConnectionInfo.protocolVersion >= Protocols.V1_17){
+            clientPlayNetworkHandler.sendPacket(packet);
+        }
+    }
+
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -21,6 +21,7 @@
   "environment": "client",
   "mixins": [
     "multiconnect.mixins.json",
+    "multiconnect.1_17.mixins.json",
     "multiconnect.1_16_5.mixins.json",
     "multiconnect.1_16_1.mixins.json",
     "multiconnect.1_15_2.mixins.json",

--- a/src/main/resources/multiconnect.1_17.mixins.json
+++ b/src/main/resources/multiconnect.1_17.mixins.json
@@ -1,0 +1,16 @@
+{
+  "required": true,
+  "package": "net.earthcomputer.multiconnect.protocols.v1_17.mixin",
+  "compatibilityLevel": "JAVA_16",
+  "mixins": [
+    "MixinClientPlayerInteractionManager"
+  ],
+  "client": [
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  },
+  "overwrites": {
+    "requireAnnotations": true
+  }
+}


### PR DESCRIPTION
In 1.17 minecraft sends a packet about your current position when you use item