### PR TITLE
Stop async translation on same version (fix #242)

### DIFF
--- a/src/main/java/net/earthcomputer/multiconnect/mixin/bridge/MixinDecoderHandler.java
+++ b/src/main/java/net/earthcomputer/multiconnect/mixin/bridge/MixinDecoderHandler.java
@@ -8,6 +8,7 @@ import net.earthcomputer.multiconnect.protocols.generic.INetworkState;
 import net.earthcomputer.multiconnect.protocols.generic.IUserDataHolder;
 import net.earthcomputer.multiconnect.protocols.generic.TypedMap;
 import net.earthcomputer.multiconnect.transformer.TransformerByteBuf;
+import net.minecraft.SharedConstants;
 import net.minecraft.network.ClientConnection;
 import net.minecraft.network.DecoderHandler;
 import net.minecraft.network.NetworkSide;
@@ -55,7 +56,9 @@ public class MixinDecoderHandler {
         INetworkState state = (INetworkState) (Object) context.channel().attr(ClientConnection.PROTOCOL_ATTRIBUTE_KEY).get();
         //noinspection ConstantConditions
         var packetInfo = state.getPacketHandlers().get(NetworkSide.CLIENTBOUND).multiconnect_getPacketInfoById(packetId.get());
-        if (ConnectionInfo.protocol.shouldTranslateAsync(packetInfo.getPacketClass())) {
+        boolean versionMismatch = ConnectionInfo.protocolVersion != SharedConstants.getProtocolVersion();
+        
+        if (versionMismatch && ConnectionInfo.protocol.shouldTranslateAsync(packetInfo.getPacketClass())) {
             byte[] data = new byte[buf.readableBytes()];
             buf.readBytes(data);
             ChunkDataTranslator.asyncTranslatePacket(context, packetInfo, data);


### PR DESCRIPTION
Hey, love your mod :D
I stumbled accross some bugs with multiconnect and block entities on my server when using the same client and server version. (https://github.com/Earthcomputer/multiconnect/issues/242)
I tried fixing it in this PR.

**Explanation what i did and why:**
Currently, all chunk data packets are synchronously processed by the ChunkDataTranslator, even if the server and client version matches. This results in a race condition for BlockEntityUpdate packets as the "waitForLoadedChunk" method does not wait if client/server version match.

There are 2 ways fixing this:
- Removing the version check in MixinClientPlayNetworkHandler#waitForLoadedChunks()
- Or: Adding a version check before delegating chunk packets to another thread in MixinDecoderHandler#transformPacketByteBuf

I decided to go with the second option because it seemed more consistent to me.

Tested and working on 1.17, 1.8 and 1.17.1. As this is a very small change, it should not affect any other versions.

I hope this helps :)