### PR TITLE
Disable axe stripping on 1.12.2 and lower

### DIFF
--- a/src/main/java/net/earthcomputer/multiconnect/protocols/v1_12_2/mixin/MixinAxeItem.java
+++ b/src/main/java/net/earthcomputer/multiconnect/protocols/v1_12_2/mixin/MixinAxeItem.java
@@ -1,0 +1,23 @@
+package net.earthcomputer.multiconnect.protocols.v1_12_2.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.earthcomputer.multiconnect.api.Protocols;
+import net.earthcomputer.multiconnect.impl.ConnectionInfo;
+import net.minecraft.item.AxeItem;
+import net.minecraft.item.ItemUsageContext;
+import net.minecraft.util.ActionResult;
+
+@Mixin(AxeItem.class)
+public class MixinAxeItem {
+
+	@Inject(method = "useOnBlock", at = @At("HEAD"), cancellable = true)
+	public void useOnBlock(ItemUsageContext context, CallbackInfoReturnable<ActionResult> ci) {
+		if (ConnectionInfo.protocolVersion <= Protocols.V1_12_2) {
+			ci.setReturnValue(ActionResult.PASS);
+		}
+	}
+}

--- a/src/main/resources/multiconnect.1_12_2.mixins.json
+++ b/src/main/resources/multiconnect.1_12_2.mixins.json
@@ -22,6 +22,7 @@
     "EntityAccessor",
     "FlowerPotBlockAccessor",
     "MixinAreaEffectCloudEntity",
+    "MixinAxeItem",
     "MixinBannerBlockEntity",
     "MixinBedBlockEntity",
     "MixinBlockItem",


### PR DESCRIPTION
Disable the log stripping feature that was added in minecraft 1.13 when right clicking with an axe on 1.12.2 servers and below.
Fixes https://github.com/Earthcomputer/multiconnect/issues/251