### PR TITLE
Remove bed bouncing

### DIFF
--- a/src/main/java/net/earthcomputer/multiconnect/protocols/v1_11_2/mixin/MixinBedBlock.java
+++ b/src/main/java/net/earthcomputer/multiconnect/protocols/v1_11_2/mixin/MixinBedBlock.java
@@ -12,7 +12,9 @@ public class MixinBedBlock {
 
     @Inject(method = "bounceEntity", at = @At("HEAD"), cancellable = true)
     public void dontBounceEntity(Entity entity, CallbackInfo ci) {
-        ci.cancel();
+        if (ConnectionInfo.protocolVersion <= Protocols.V1_11_2) {
+            ci.cancel();
+        }
     }
 
 }

--- a/src/main/java/net/earthcomputer/multiconnect/protocols/v1_11_2/mixin/MixinBedBlock.java
+++ b/src/main/java/net/earthcomputer/multiconnect/protocols/v1_11_2/mixin/MixinBedBlock.java
@@ -1,6 +1,6 @@
 package net.earthcomputer.multiconnect.protocols.v1_11_2.mixin;
 
-mport net.minecraft.block.BedBlock;
+import net.minecraft.block.BedBlock;
 import net.minecraft.entity.Entity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;

--- a/src/main/java/net/earthcomputer/multiconnect/protocols/v1_11_2/mixin/MixinBedBlock.java
+++ b/src/main/java/net/earthcomputer/multiconnect/protocols/v1_11_2/mixin/MixinBedBlock.java
@@ -1,0 +1,18 @@
+package net.earthcomputer.multiconnect.protocols.v1_11_2.mixin;
+
+mport net.minecraft.block.BedBlock;
+import net.minecraft.entity.Entity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(BedBlock.class)
+public class MixinBedBlock {
+
+    @Inject(method = "bounceEntity", at = @At("HEAD"), cancellable = true)
+    public void dontBounceEntity(Entity entity, CallbackInfo ci) {
+        ci.cancel();
+    }
+
+}

--- a/src/main/resources/multiconnect.1_11_2.mixins.json
+++ b/src/main/resources/multiconnect.1_11_2.mixins.json
@@ -9,6 +9,7 @@
     "MixinPlayerEntityRenderer",
     "MixinPlayerScreenHandler",
     "MixinScreenHandler",
+    "MixinBedBlock",
     "PlayerEntityAccessor"
   ],
   "client": [


### PR DESCRIPTION
Bed bouncing was added in 1.12. This removes it for versions below 1.12.
Didn't have time to check the code for syntax, because im unable to build multiconnect right now.
Please check the code for errors before merging.
![grafik](https://user-images.githubusercontent.com/52950755/139558893-ff8b8483-3322-4d14-97fa-a1e7bbf5b9f6.png)
