### PR TITLE
fix lilypads in 1.8

### DIFF
--- a/src/main/java/net/earthcomputer/multiconnect/protocols/v1_8/Protocol_1_8.java
+++ b/src/main/java/net/earthcomputer/multiconnect/protocols/v1_8/Protocol_1_8.java
@@ -1008,6 +1008,7 @@ public class Protocol_1_8 extends Protocol_1_9 {
     protected void markChangedCollisionBoxes() {
         super.markChangedCollisionBoxes();
         markCollisionBoxChanged(Blocks.LADDER);
+        markCollisionBoxChanged(Blocks.LILY_PAD);
     }
 
     @Override

--- a/src/main/java/net/earthcomputer/multiconnect/protocols/v1_8/mixin/MixinLilyPadBlock.java
+++ b/src/main/java/net/earthcomputer/multiconnect/protocols/v1_8/mixin/MixinLilyPadBlock.java
@@ -1,0 +1,29 @@
+package net.earthcomputer.multiconnect.protocols.v1_8.mixin;
+
+import net.earthcomputer.multiconnect.api.Protocols;
+import net.earthcomputer.multiconnect.impl.ConnectionInfo;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.LilyPadBlock;
+import net.minecraft.block.ShapeContext;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.shape.VoxelShape;
+import net.minecraft.world.BlockView;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(LilyPadBlock.class)
+public class MixinLilyPadBlock {
+
+    private static final VoxelShape SHAPE = Block.createCuboidShape(0.0D, 0.0D, 0.0D, 16.0D, 0.015625D /* 1 / 64 */ * 16, 16.0D);
+
+    @Inject(method = "getOutlineShape", at = @At("HEAD"), cancellable = true)
+    public void changeBoundingBox(BlockState state, BlockView world, BlockPos pos, ShapeContext context, CallbackInfoReturnable<VoxelShape> cir) {
+        if(ConnectionInfo.protocolVersion <= Protocols.V1_8) {
+            cir.setReturnValue(SHAPE);
+        }
+    }
+
+}

--- a/src/main/resources/multiconnect.1_8.mixins.json
+++ b/src/main/resources/multiconnect.1_8.mixins.json
@@ -32,6 +32,7 @@
     "MixinItemCooldownManager",
     "MixinItemStack",
     "MixinLadderBlock",
+    "MixinLilyPadBlock",
     "MixinLivingEntity",
     "MixinMinecraftClient",
     "MixinPlayerEntity",


### PR DESCRIPTION
The boundingbox of lilypads is different for 1.8.