### PR TITLE
Fix swing packets not sent when attacking two times in a single tick

### DIFF
--- a/src/main/java/net/earthcomputer/multiconnect/protocols/v1_8/IClientPlayer.java
+++ b/src/main/java/net/earthcomputer/multiconnect/protocols/v1_8/IClientPlayer.java
@@ -1,6 +1,5 @@
 package net.earthcomputer.multiconnect.protocols.v1_8;
 
 public interface IClientPlayer {
-    void multiconnect_cancelSwingsThisTick();
-    void multiconnect_uncancelSwings();
+    void multiconnect_cancelSwingPacket();
 }

--- a/src/main/java/net/earthcomputer/multiconnect/protocols/v1_8/mixin/MixinClientPlayerEntity.java
+++ b/src/main/java/net/earthcomputer/multiconnect/protocols/v1_8/mixin/MixinClientPlayerEntity.java
@@ -31,6 +31,7 @@ public class MixinClientPlayerEntity extends AbstractClientPlayerEntity implemen
         if (ConnectionInfo.protocolVersion <= Protocols.V1_8 && areSwingsCanceledThisTick) {
             // the first tick of hand swinging, we may have sent the hand swing earlier in 1.8
             ci.cancel();
+            areSwingsCanceledThisTick = false;
         }
     }
 

--- a/src/main/java/net/earthcomputer/multiconnect/protocols/v1_8/mixin/MixinClientPlayerEntity.java
+++ b/src/main/java/net/earthcomputer/multiconnect/protocols/v1_8/mixin/MixinClientPlayerEntity.java
@@ -20,7 +20,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public class MixinClientPlayerEntity extends AbstractClientPlayerEntity implements IClientPlayer {
     @Shadow private boolean lastOnGround;
 
-    @Unique private boolean areSwingsCanceledThisTick = false;
+    @Unique private boolean cancelSwingPacket = false;
 
     public MixinClientPlayerEntity(ClientWorld world, GameProfile profile) {
         super(world, profile);
@@ -28,10 +28,9 @@ public class MixinClientPlayerEntity extends AbstractClientPlayerEntity implemen
 
     @Inject(method = "swingHand", at = @At("HEAD"), cancellable = true)
     private void checkSwingHandRate(CallbackInfo ci) {
-        if (ConnectionInfo.protocolVersion <= Protocols.V1_8 && areSwingsCanceledThisTick) {
-            // the first tick of hand swinging, we may have sent the hand swing earlier in 1.8
+        if (ConnectionInfo.protocolVersion <= Protocols.V1_8 && cancelSwingPacket) {
             ci.cancel();
-            areSwingsCanceledThisTick = false;
+            cancelSwingPacket = false;
         }
     }
 
@@ -45,12 +44,7 @@ public class MixinClientPlayerEntity extends AbstractClientPlayerEntity implemen
     }
 
     @Override
-    public void multiconnect_cancelSwingsThisTick() {
-        areSwingsCanceledThisTick = true;
-    }
-
-    @Override
-    public void multiconnect_uncancelSwings() {
-        areSwingsCanceledThisTick = false;
+    public void multiconnect_cancelSwingPacket() {
+        cancelSwingPacket = true;
     }
 }

--- a/src/main/java/net/earthcomputer/multiconnect/protocols/v1_8/mixin/MixinClientPlayerInteractionManager.java
+++ b/src/main/java/net/earthcomputer/multiconnect/protocols/v1_8/mixin/MixinClientPlayerInteractionManager.java
@@ -20,7 +20,7 @@ public class MixinClientPlayerInteractionManager {
         // The hand swing and attack packets are the other way around in 1.8. Fixes anti-cheat triggering
         if (ConnectionInfo.protocolVersion <= Protocols.V1_8) {
             player.swingHand(Hand.MAIN_HAND);
-            ((IClientPlayer) player).multiconnect_cancelSwingsThisTick();
+            ((IClientPlayer) player).multiconnect_cancelSwingPacket();
         }
     }
 

--- a/src/main/java/net/earthcomputer/multiconnect/protocols/v1_8/mixin/MixinLivingEntity.java
+++ b/src/main/java/net/earthcomputer/multiconnect/protocols/v1_8/mixin/MixinLivingEntity.java
@@ -2,25 +2,16 @@ package net.earthcomputer.multiconnect.protocols.v1_8.mixin;
 
 import net.earthcomputer.multiconnect.api.Protocols;
 import net.earthcomputer.multiconnect.impl.ConnectionInfo;
-import net.earthcomputer.multiconnect.protocols.v1_8.IClientPlayer;
 import net.minecraft.entity.LivingEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(LivingEntity.class)
 public class MixinLivingEntity {
-    @Inject(method = "tickHandSwing", at = @At("HEAD"))
-    private void onTickHandSwing(CallbackInfo ci) {
-        if (ConnectionInfo.protocolVersion <= Protocols.V1_8 && this instanceof IClientPlayer clientPlayer) {
-            clientPlayer.multiconnect_uncancelSwings();
-        }
-    }
-
     @ModifyConstant(method = "tickMovement", constant = @Constant(doubleValue = 0.003D))
     public double modifyVelocityZero(final double constant) {
         if (ConnectionInfo.protocolVersion <= Protocols.V1_8) return 0.005D;


### PR DESCRIPTION
If you attack a player two times in a tick it will not send the second swing packet. This fixes it. AntiCheats no longer flag NoSwing when double clicking.

Might have been why the minemen anticheat was banning players.