### PR TITLE
fix via not launch issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -135,7 +135,8 @@ dependencies {
 	// compileOnly project(':stubs') // when https://github.com/FabricMC/fabric-loom/pull/747 is merged
 	implementation project(':translator-api')
 
-	runtimeOnly project(':via-translator')
+	runtimeOnly project(path: ':via-translator', configuration: "namedElements")
+	runtimeOnly project(path: ':via-translator')
 
 	compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
 


### PR DESCRIPTION
fixes #485 

tl;dr `configuration: "namedElements"` passes output to runtimeOnly (but not dependencies), while not having it only passes the dependencies but not the output. weird loom stuff

btw
> The root project does not have a dependency on ViaVersion - only on Minecraft (which needs Loom).

is technically not possible as it's a hard dependency in the via-translator subproject so it is transitively in the root...

