### PR TITLE
Fix fabric-api compatibilty

### DIFF
--- a/src/main/java/net/earthcomputer/multiconnect/mixin/connect/BuiltInRegistriesMixin.java
+++ b/src/main/java/net/earthcomputer/multiconnect/mixin/connect/BuiltInRegistriesMixin.java
@@ -3,14 +3,13 @@ package net.earthcomputer.multiconnect.mixin.connect;
 import net.earthcomputer.multiconnect.protocols.generic.MulticonnectAddedRegistryEntries;
 import net.minecraft.core.registries.BuiltInRegistries;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(BuiltInRegistries.class)
 public class BuiltInRegistriesMixin {
-    @Inject(method = "createContents()V", at = @At("HEAD"))
+    @Inject(method = "createContents()V", at = @At("RETURN"))
     private static void preFreezeRegistries(CallbackInfo ci) {
         MulticonnectAddedRegistryEntries.register();
     }

--- a/src/main/java/net/earthcomputer/multiconnect/mixin/connect/BuiltInRegistriesMixin.java
+++ b/src/main/java/net/earthcomputer/multiconnect/mixin/connect/BuiltInRegistriesMixin.java
@@ -3,13 +3,14 @@ package net.earthcomputer.multiconnect.mixin.connect;
 import net.earthcomputer.multiconnect.protocols.generic.MulticonnectAddedRegistryEntries;
 import net.minecraft.core.registries.BuiltInRegistries;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(BuiltInRegistries.class)
 public class BuiltInRegistriesMixin {
-    @Inject(method = "bootStrap", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/registries/BuiltInRegistries;freeze()V"))
+    @Inject(method = "createContents()V", at = @At("HEAD"))
     private static void preFreezeRegistries(CallbackInfo ci) {
         MulticonnectAddedRegistryEntries.register();
     }


### PR DESCRIPTION
Fixes #494 by moving the point multiconnect registers its content slightly.

This works fine w/o any additional mods on either modding platform,
works fine with floader and fabric-api,
however using quilt and qsl+qfapi this method is called twice and will crash still. I contacted @EnnuiL on Discord to hopefully get this resolved as it also messes with other mods (such as mine, but I did not look into it as much at the time I updated it).