### PR TITLE
Many improvements and fixes

### DIFF
--- a/src/main/java/net/earthcomputer/multiconnect/api/IProtocol.java
+++ b/src/main/java/net/earthcomputer/multiconnect/api/IProtocol.java
@@ -52,7 +52,7 @@ public interface IProtocol {
      * including this protocol. Throws an exception if this protocol is not a major release.
      */
     @ThreadSafe
-    List<IProtocol> getMinorReleases();
+    List<? extends IProtocol> getMinorReleases();
 
     /**
      * Returns whether this protocol is only in beta support by multiconnect, and may have stability issues when

--- a/src/main/java/net/earthcomputer/multiconnect/api/IProtocol.java
+++ b/src/main/java/net/earthcomputer/multiconnect/api/IProtocol.java
@@ -61,4 +61,6 @@ public interface IProtocol {
     @ThreadSafe
     boolean isMulticonnectBeta();
 
+    boolean isMulticonnectExtension();
+
 }

--- a/src/main/java/net/earthcomputer/multiconnect/api/MultiConnectAPI.java
+++ b/src/main/java/net/earthcomputer/multiconnect/api/MultiConnectAPI.java
@@ -306,6 +306,11 @@ public class MultiConnectAPI {
         public boolean isMulticonnectBeta() {
             return false;
         }
+
+        @Override
+        public boolean isMulticonnectExtension() {
+            return false;
+        }
     }
 
     //endregion

--- a/src/main/java/net/earthcomputer/multiconnect/connect/ConnectionMode.java
+++ b/src/main/java/net/earthcomputer/multiconnect/connect/ConnectionMode.java
@@ -46,14 +46,14 @@ public final class ConnectionMode implements IProtocol {
     public static final ConnectionMode V1_12_2 = register("1.12.2", Protocols.V1_12_2, 1343, InitFlags.MULTICONNECT_BETA);
     public static final ConnectionMode V1_12_1 = register("1.12.1", Protocols.V1_12_1, 1241, InitFlags.MULTICONNECT_BETA);
     public static final ConnectionMode V1_12 = register("1.12", Protocols.V1_12, 1139, InitFlags.MAJOR_RELEASE | InitFlags.MULTICONNECT_BETA);
-//    V1_11_2("1.11.2", Protocols.V1_11_2, 922),
-//    V1_11("1.11", Protocols.V1_11, 921, InitFlags.MAJOR_RELEASE),
-//    V1_10("1.10", Protocols.V1_10, 512, InitFlags.MAJOR_RELEASE | InitFlags.MULTICONNECT_BETA),
-//    V1_9_4("1.9.4", Protocols.V1_9_4, 184, InitFlags.MULTICONNECT_BETA),
-//    V1_9_2("1.9.2", Protocols.V1_9_2, 176, InitFlags.MULTICONNECT_BETA),
-//    V1_9_1("1.9.1", Protocols.V1_9_1, 175, InitFlags.MULTICONNECT_BETA),
-//    V1_9("1.9", Protocols.V1_9, 169, InitFlags.MAJOR_RELEASE | InitFlags.MULTICONNECT_BETA),
-//    V1_8("1.8", Protocols.V1_8, 99, InitFlags.MAJOR_RELEASE | InitFlags.MULTICONNECT_BETA),
+    public static final ConnectionMode V1_11_2 = register("1.11.2", Protocols.V1_11_2, 922);
+    public static final ConnectionMode V1_11 = register("1.11", Protocols.V1_11, 921, InitFlags.MAJOR_RELEASE);
+    public static final ConnectionMode V1_10 = register("1.10", Protocols.V1_10, 512, InitFlags.MAJOR_RELEASE | InitFlags.MULTICONNECT_BETA);
+    public static final ConnectionMode V1_9_4 = register("1.9.4", Protocols.V1_9_4, 184, InitFlags.MULTICONNECT_BETA);
+    public static final ConnectionMode V1_9_2 = register("1.9.2", Protocols.V1_9_2, 176, InitFlags.MULTICONNECT_BETA);
+    public static final ConnectionMode V1_9_1 = register("1.9.1", Protocols.V1_9_1, 175, InitFlags.MULTICONNECT_BETA);
+    public static final ConnectionMode V1_9 = register("1.9", Protocols.V1_9, 169, InitFlags.MAJOR_RELEASE | InitFlags.MULTICONNECT_BETA);
+    public static final ConnectionMode V1_8 = register("1.8", Protocols.V1_8, 99, InitFlags.MAJOR_RELEASE | InitFlags.MULTICONNECT_BETA);
     // the last value MUST be considered a "major release"
 
     public static class InitFlags {

--- a/src/main/java/net/earthcomputer/multiconnect/connect/ConnectionMode.java
+++ b/src/main/java/net/earthcomputer/multiconnect/connect/ConnectionMode.java
@@ -59,6 +59,7 @@ public final class ConnectionMode implements IProtocol {
     public static class InitFlags {
         private static final int MAJOR_RELEASE = 1;
         private static final int MULTICONNECT_BETA = 2;
+        private static final int MULTICONNECT_EXTENSION = 4;
     }
 
     private final int value;
@@ -67,6 +68,7 @@ public final class ConnectionMode implements IProtocol {
     private final String majorReleaseName;
     private final int dataVersion;
     private final boolean multiconnectBeta;
+    private final boolean multiconnectExtension;
     private final int ordinal = nextOrdinal++;
 
     private ConnectionMode(String name, int value, int dataVersion) {
@@ -84,6 +86,7 @@ public final class ConnectionMode implements IProtocol {
         this.dataVersion = dataVersion;
         this.majorReleaseName = majorReleaseName;
         this.multiconnectBeta = (initializationFlags & InitFlags.MULTICONNECT_BETA) != 0;
+        this.multiconnectExtension = (initializationFlags & InitFlags.MULTICONNECT_EXTENSION) != 0;
     }
 
     public int ordinal() {
@@ -130,6 +133,11 @@ public final class ConnectionMode implements IProtocol {
     @Override
     public boolean isMulticonnectBeta() {
         return multiconnectBeta;
+    }
+
+    @Override
+    public boolean isMulticonnectExtension() {
+        return multiconnectExtension;
     }
 
     @Override

--- a/src/main/java/net/earthcomputer/multiconnect/connect/ConnectionMode.java
+++ b/src/main/java/net/earthcomputer/multiconnect/connect/ConnectionMode.java
@@ -3,42 +3,49 @@ package net.earthcomputer.multiconnect.connect;
 import com.google.common.collect.Lists;
 import net.earthcomputer.multiconnect.api.IProtocol;
 import net.earthcomputer.multiconnect.api.Protocols;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 
 /**
  * Enum constants for each protocol, and the auto connection mode
  */
-public enum ConnectionMode implements IProtocol {
+public final class ConnectionMode implements IProtocol {
+
+    private static final List<ConnectionMode> ALL_MODES = new ArrayList<>();
+    private static ConnectionMode @Nullable [] protocols = null;
+    private static final Map<Integer, ConnectionMode> BY_VALUE = new HashMap<>();
+    private static final Set<String> VALID_NAMES = new HashSet<>();
+    private static int nextOrdinal = 0;
 
     // Protocols should go in reverse chronological order
-    AUTO("Auto", -1, -1, InitFlags.MAJOR_RELEASE),
-    V1_19_3("1.19.3", Protocols.V1_19_3, 3218),
-    V1_19_2("1.19.2", Protocols.V1_19_2, 3117),
-    V1_19("1.19", Protocols.V1_19, 3105, InitFlags.MAJOR_RELEASE),
-    V1_18_2("1.18.2", Protocols.V1_18_2, 2975),
-    V1_18("1.18", Protocols.V1_18, 2865, InitFlags.MAJOR_RELEASE),
-    V1_17_1("1.17.1", Protocols.V1_17_1, 2730),
-    V1_17("1.17", Protocols.V1_17, 2724, InitFlags.MAJOR_RELEASE),
-    V1_16_5("1.16.5", Protocols.V1_16_5, 2584),
-    V1_16_3("1.16.3", Protocols.V1_16_3, 2580),
-    V1_16_2("1.16.2", Protocols.V1_16_2, 2578),
-    V1_16_1("1.16.1", Protocols.V1_16_1, 2567),
-    V1_16("1.16", Protocols.V1_16, 2566, InitFlags.MAJOR_RELEASE),
-    V1_15_2("1.15.2", Protocols.V1_15_2, 2230),
-    V1_15_1("1.15.1", Protocols.V1_15_1, 2227),
-    V1_15("1.15", Protocols.V1_15, 2225, InitFlags.MAJOR_RELEASE),
-    V1_14_4("1.14.4", Protocols.V1_14_4, 1976),
-    V1_14_3("1.14.3", Protocols.V1_14_3, 1968),
-    V1_14_2("1.14.2", Protocols.V1_14_2, 1963),
-    V1_14_1("1.14.1", Protocols.V1_14_1, 1957),
-    V1_14("1.14", Protocols.V1_14, 1952, InitFlags.MAJOR_RELEASE),
-    V1_13_2("1.13.2", Protocols.V1_13_2, 1631),
-    V1_13_1("1.13.1", Protocols.V1_13_1, 1628),
-    V1_13("1.13", Protocols.V1_13, 1519, InitFlags.MAJOR_RELEASE),
-    V1_12_2("1.12.2", Protocols.V1_12_2, 1343, InitFlags.MULTICONNECT_BETA),
-    V1_12_1("1.12.1", Protocols.V1_12_1, 1241, InitFlags.MULTICONNECT_BETA),
-    V1_12("1.12", Protocols.V1_12, 1139, InitFlags.MAJOR_RELEASE | InitFlags.MULTICONNECT_BETA),
+    public static final ConnectionMode AUTO = register("Auto", -1, -1, InitFlags.MAJOR_RELEASE);
+    public static final ConnectionMode V1_19_3 = register("1.19.3", Protocols.V1_19_3, 3218);
+    public static final ConnectionMode V1_19_2 = register("1.19.2", Protocols.V1_19_2, 3117);
+    public static final ConnectionMode V1_19 = register("1.19", Protocols.V1_19, 3105, InitFlags.MAJOR_RELEASE);
+    public static final ConnectionMode V1_18_2 = register("1.18.2", Protocols.V1_18_2, 2975);
+    public static final ConnectionMode V1_18 = register("1.18", Protocols.V1_18, 2865, InitFlags.MAJOR_RELEASE);
+    public static final ConnectionMode V1_17_1 = register("1.17.1", Protocols.V1_17_1, 2730);
+    public static final ConnectionMode V1_17 = register("1.17", Protocols.V1_17, 2724, InitFlags.MAJOR_RELEASE);
+    public static final ConnectionMode V1_16_5 = register("1.16.5", Protocols.V1_16_5, 2584);
+    public static final ConnectionMode V1_16_3 = register("1.16.3", Protocols.V1_16_3, 2580);
+    public static final ConnectionMode V1_16_2 = register("1.16.2", Protocols.V1_16_2, 2578);
+    public static final ConnectionMode V1_16_1 = register("1.16.1", Protocols.V1_16_1, 2567);
+    public static final ConnectionMode V1_16 = register("1.16", Protocols.V1_16, 2566, InitFlags.MAJOR_RELEASE);
+    public static final ConnectionMode V1_15_2 = register("1.15.2", Protocols.V1_15_2, 2230);
+    public static final ConnectionMode V1_15_1 = register("1.15.1", Protocols.V1_15_1, 2227);
+    public static final ConnectionMode V1_15 = register("1.15", Protocols.V1_15, 2225, InitFlags.MAJOR_RELEASE);
+    public static final ConnectionMode V1_14_4 = register("1.14.4", Protocols.V1_14_4, 1976);
+    public static final ConnectionMode V1_14_3 = register("1.14.3", Protocols.V1_14_3, 1968);
+    public static final ConnectionMode V1_14_2 = register("1.14.2", Protocols.V1_14_2, 1963);
+    public static final ConnectionMode V1_14_1 = register("1.14.1", Protocols.V1_14_1, 1957);
+    public static final ConnectionMode V1_14 = register("1.14", Protocols.V1_14, 1952, InitFlags.MAJOR_RELEASE);
+    public static final ConnectionMode V1_13_2 = register("1.13.2", Protocols.V1_13_2, 1631);
+    public static final ConnectionMode V1_13_1 = register("1.13.1", Protocols.V1_13_1, 1628);
+    public static final ConnectionMode V1_13 = register("1.13", Protocols.V1_13, 1519, InitFlags.MAJOR_RELEASE);
+    public static final ConnectionMode V1_12_2 = register("1.12.2", Protocols.V1_12_2, 1343, InitFlags.MULTICONNECT_BETA);
+    public static final ConnectionMode V1_12_1 = register("1.12.1", Protocols.V1_12_1, 1241, InitFlags.MULTICONNECT_BETA);
+    public static final ConnectionMode V1_12 = register("1.12", Protocols.V1_12, 1139, InitFlags.MAJOR_RELEASE | InitFlags.MULTICONNECT_BETA);
 //    V1_11_2("1.11.2", Protocols.V1_11_2, 922),
 //    V1_11("1.11", Protocols.V1_11, 921, InitFlags.MAJOR_RELEASE),
 //    V1_10("1.10", Protocols.V1_10, 512, InitFlags.MAJOR_RELEASE | InitFlags.MULTICONNECT_BETA),
@@ -48,9 +55,8 @@ public enum ConnectionMode implements IProtocol {
 //    V1_9("1.9", Protocols.V1_9, 169, InitFlags.MAJOR_RELEASE | InitFlags.MULTICONNECT_BETA),
 //    V1_8("1.8", Protocols.V1_8, 99, InitFlags.MAJOR_RELEASE | InitFlags.MULTICONNECT_BETA),
     // the last value MUST be considered a "major release"
-    ;
 
-    private static class InitFlags {
+    public static class InitFlags {
         private static final int MAJOR_RELEASE = 1;
         private static final int MULTICONNECT_BETA = 2;
     }
@@ -61,22 +67,27 @@ public enum ConnectionMode implements IProtocol {
     private final String majorReleaseName;
     private final int dataVersion;
     private final boolean multiconnectBeta;
+    private final int ordinal = nextOrdinal++;
 
-    ConnectionMode(String name, int value, int dataVersion) {
+    private ConnectionMode(String name, int value, int dataVersion) {
         this(name, value, dataVersion, 0);
     }
 
-    ConnectionMode(String name, int value, int dataVersion, int initializationFlags) {
+    private ConnectionMode(String name, int value, int dataVersion, int initializationFlags) {
         this(name, value, dataVersion, name, initializationFlags);
     }
 
-    ConnectionMode(String name, int value, int dataVersion, String majorReleaseName, int initializationFlags) {
+    private ConnectionMode(String name, int value, int dataVersion, String majorReleaseName, int initializationFlags) {
         this.value = value;
         this.majorRelease = (initializationFlags & InitFlags.MAJOR_RELEASE) != 0;
         this.name = name;
         this.dataVersion = dataVersion;
         this.majorReleaseName = majorReleaseName;
         this.multiconnectBeta = (initializationFlags & InitFlags.MULTICONNECT_BETA) != 0;
+    }
+
+    public int ordinal() {
+        return ordinal;
     }
 
     @Override
@@ -93,9 +104,9 @@ public enum ConnectionMode implements IProtocol {
     public ConnectionMode getMajorRelease() {
         int i;
         //noinspection StatementWithEmptyBody
-        for (i = ordinal(); !VALUES[i].majorRelease; i++)
+        for (i = ordinal(); !ALL_MODES.get(i).majorRelease; i++)
             ;
-        return VALUES[i];
+        return ALL_MODES.get(i);
     }
 
     @Override
@@ -104,16 +115,16 @@ public enum ConnectionMode implements IProtocol {
     }
 
     @Override
-    public List<IProtocol> getMinorReleases() {
+    public List<? extends IProtocol> getMinorReleases() {
         if (!majorRelease) {
             throw new UnsupportedOperationException("Cannot call IProtocol.getMinorReleases() on a non-major release");
         }
         int endIndex = ordinal();
         int startIndex;
         //noinspection StatementWithEmptyBody
-        for (startIndex = endIndex - 1; startIndex >= 0 && !VALUES[startIndex].majorRelease; startIndex--)
+        for (startIndex = endIndex - 1; startIndex >= 0 && !ALL_MODES.get(startIndex).majorRelease; startIndex--)
             ;
-        return Lists.reverse(Arrays.<IProtocol>asList(VALUES).subList(startIndex + 1, endIndex + 1));
+        return Lists.reverse(ALL_MODES.subList(startIndex + 1, endIndex + 1));
     }
 
     @Override
@@ -131,20 +142,36 @@ public enum ConnectionMode implements IProtocol {
         return dataVersion;
     }
 
-    private static final ConnectionMode[] VALUES = values();
-    private static final ConnectionMode[] PROTOCOLS = Arrays.stream(VALUES).filter(it -> it != AUTO).toArray(ConnectionMode[]::new);
-    private static final Map<Integer, ConnectionMode> BY_VALUE = new HashMap<>();
-    private static final Set<String> VALID_NAMES = new HashSet<>();
-
     public static ConnectionMode byValue(int value) {
-        return BY_VALUE.getOrDefault(value, AUTO);
+        return getByValueMap().getOrDefault(value, AUTO);
     }
 
     /**
      * Newest to oldest
      */
     public static ConnectionMode[] protocolValues() {
-        return PROTOCOLS;
+        if (protocols == null) {
+            protocols = ALL_MODES.stream().filter(it -> it != AUTO).toArray(ConnectionMode[]::new);
+        }
+        return protocols;
+    }
+
+    private static Map<Integer, ConnectionMode> getByValueMap() {
+        if (BY_VALUE.isEmpty()) {
+            for (final ConnectionMode value : ALL_MODES) {
+                BY_VALUE.put(value.getValue(), value);
+            }
+        }
+        return BY_VALUE;
+    }
+
+    private static Set<String> getValidNames() {
+        if (VALID_NAMES.isEmpty()) {
+            for (final ConnectionMode value : ALL_MODES) {
+                VALID_NAMES.add(value.getName());
+            }
+        }
+        return VALID_NAMES;
     }
 
     public static boolean isSupportedProtocol(int protocol) {
@@ -152,14 +179,33 @@ public enum ConnectionMode implements IProtocol {
     }
 
     public static boolean isSupportedVersionName(String name) {
-        return VALID_NAMES.contains(name);
+        return getValidNames().contains(name);
     }
 
-    static {
-        for (ConnectionMode value : VALUES) {
-            BY_VALUE.put(value.getValue(), value);
-            VALID_NAMES.add(value.getName());
-        }
+    public static ConnectionMode[] values() { // Binary compatibility
+        return ALL_MODES.toArray(ConnectionMode[]::new);
     }
 
+    private static ConnectionMode register(ConnectionMode mode) {
+        ALL_MODES.add(mode);
+
+        // Now clear these caches
+        protocols = null;
+        BY_VALUE.clear();
+        VALID_NAMES.clear();
+
+        return mode;
+    }
+
+    public static ConnectionMode register(String name, int value, int dataVersion) {
+        return register(new ConnectionMode(name, value, dataVersion));
+    }
+
+    public static ConnectionMode register(String name, int value, int dataVersion, int initializationFlags) {
+        return register(new ConnectionMode(name, value, dataVersion, initializationFlags));
+    }
+
+    public static ConnectionMode register(String name, int value, int dataVersion, String majorReleaseName, int initializationFlags) {
+        return register(new ConnectionMode(name, value, dataVersion, majorReleaseName, initializationFlags));
+    }
 }

--- a/src/main/java/net/earthcomputer/multiconnect/connect/ConnectionMode.java
+++ b/src/main/java/net/earthcomputer/multiconnect/connect/ConnectionMode.java
@@ -57,9 +57,9 @@ public final class ConnectionMode implements IProtocol {
     // the last value MUST be considered a "major release"
 
     public static class InitFlags {
-        private static final int MAJOR_RELEASE = 1;
-        private static final int MULTICONNECT_BETA = 2;
-        private static final int MULTICONNECT_EXTENSION = 4;
+        public static final int MAJOR_RELEASE = 1;
+        public static final int MULTICONNECT_BETA = 2;
+        public static final int MULTICONNECT_EXTENSION = 4;
     }
 
     private final int value;

--- a/src/main/java/net/earthcomputer/multiconnect/impl/Utils.java
+++ b/src/main/java/net/earthcomputer/multiconnect/impl/Utils.java
@@ -49,7 +49,7 @@ public class Utils {
         for (ConnectionMode mode : ConnectionMode.values()) {
             if (mode.isMajorRelease()) {
                 var category = versionDropDown.add(mode);
-                List<IProtocol> children = mode.getMinorReleases();
+                List<? extends IProtocol> children = mode.getMinorReleases();
                 if (children.size() > 1) {
                     for (IProtocol child : children) {
                         category.add((ConnectionMode) child);

--- a/src/main/java/net/earthcomputer/multiconnect/impl/Utils.java
+++ b/src/main/java/net/earthcomputer/multiconnect/impl/Utils.java
@@ -26,6 +26,9 @@ public class Utils {
             if (mode.isMulticonnectBeta()) {
                 text.append(Component.literal(" !").withStyle(ChatFormatting.RED));
             }
+            if (mode.isMulticonnectExtension()) {
+                text.append(Component.literal(" e").withStyle(ChatFormatting.GOLD));
+            }
             return text;
         })
                 .setCategoryLabelExtractor(mode -> {
@@ -33,15 +36,27 @@ public class Utils {
                     if (mode.isMulticonnectBeta()) {
                         text.append(Component.literal(" !").withStyle(ChatFormatting.RED));
                     }
+                    if (mode.isMulticonnectExtension()) {
+                        text.append(Component.literal(" e").withStyle(ChatFormatting.GOLD));
+                    }
                     return text;
                 })
                 .setTooltipRenderer((matrices, mode, x, y, isCategory) -> {
+                    final List<Component> tooltip = new ArrayList<>();
                     if (mode.isMulticonnectBeta()) {
                         String modeName = isCategory ? mode.getMajorReleaseName() : mode.getName();
-                        screen.renderComponentTooltip(matrices, ImmutableList.of(
-                                Component.translatable("multiconnect.betaWarning.line1", modeName),
-                                Component.translatable("multiconnect.betaWarning.line2", modeName)
-                        ), x, y);
+                        tooltip.add(Component.translatable("multiconnect.betaWarning.line1", modeName));
+                        if (!mode.isMulticonnectExtension()) {
+                            tooltip.add(Component.translatable("multiconnect.betaWarning.line2", modeName));
+                        }
+                    }
+                    if (mode.isMulticonnectExtension()) {
+                        String modeName = isCategory ? mode.getMajorReleaseName() : mode.getName();
+                        tooltip.add(Component.translatable("multiconnect.extensionWarning.line1", modeName));
+                        tooltip.add(Component.translatable("multiconnect.extensionWarning.line2", modeName));
+                    }
+                    if (!tooltip.isEmpty()) {
+                        screen.renderComponentTooltip(matrices, tooltip, x, y);
                     }
                 });
 

--- a/src/main/java/net/earthcomputer/multiconnect/mixin/connect/ConnectScreen1Mixin.java
+++ b/src/main/java/net/earthcomputer/multiconnect/mixin/connect/ConnectScreen1Mixin.java
@@ -1,7 +1,6 @@
 package net.earthcomputer.multiconnect.mixin.connect;
 
 import net.earthcomputer.multiconnect.connect.ConnectionHandler;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ServerData;
 import net.minecraft.client.multiplayer.resolver.ServerAddress;
 import net.minecraft.network.Connection;
@@ -24,10 +23,13 @@ public class ConnectScreen1Mixin {
     @Final
     ServerAddress val$hostAndPort;
 
+    @Shadow(aliases = "field_40415", remap = false)
+    @Final
+    ServerData val$server;
+
     @Inject(method = "run()V", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/Connection;connectToServer(Ljava/net/InetSocketAddress;Z)Lnet/minecraft/network/Connection;"), cancellable = true, locals = LocalCapture.CAPTURE_FAILHARD)
     public void beforeConnect(CallbackInfo ci, InetSocketAddress address) {
-        ServerData serverEntry = Minecraft.getInstance().getCurrentServer();
-        if (!ConnectionHandler.preConnect(address, val$hostAndPort, serverEntry == null ? null : serverEntry.ip)) {
+        if (!ConnectionHandler.preConnect(address, val$hostAndPort, val$server.ip)) {
             ci.cancel();
         }
     }

--- a/src/main/java/net/earthcomputer/multiconnect/protocols/ProtocolRegistry.java
+++ b/src/main/java/net/earthcomputer/multiconnect/protocols/ProtocolRegistry.java
@@ -11,19 +11,11 @@ import net.earthcomputer.multiconnect.protocols.v1_12.Protocol_1_12_2;
 import net.earthcomputer.multiconnect.protocols.v1_13.Protocol_1_13;
 import net.earthcomputer.multiconnect.protocols.v1_13.Protocol_1_13_1;
 import net.earthcomputer.multiconnect.protocols.v1_13.Protocol_1_13_2;
-import net.earthcomputer.multiconnect.protocols.v1_14.Protocol_1_14;
-import net.earthcomputer.multiconnect.protocols.v1_14.Protocol_1_14_1;
-import net.earthcomputer.multiconnect.protocols.v1_14.Protocol_1_14_2;
-import net.earthcomputer.multiconnect.protocols.v1_14.Protocol_1_14_3;
-import net.earthcomputer.multiconnect.protocols.v1_14.Protocol_1_14_4;
+import net.earthcomputer.multiconnect.protocols.v1_14.*;
 import net.earthcomputer.multiconnect.protocols.v1_15.Protocol_1_15;
 import net.earthcomputer.multiconnect.protocols.v1_15.Protocol_1_15_1;
 import net.earthcomputer.multiconnect.protocols.v1_15.Protocol_1_15_2;
-import net.earthcomputer.multiconnect.protocols.v1_16.Protocol_1_16;
-import net.earthcomputer.multiconnect.protocols.v1_16.Protocol_1_16_1;
-import net.earthcomputer.multiconnect.protocols.v1_16.Protocol_1_16_2;
-import net.earthcomputer.multiconnect.protocols.v1_16.Protocol_1_16_3;
-import net.earthcomputer.multiconnect.protocols.v1_16.Protocol_1_16_5;
+import net.earthcomputer.multiconnect.protocols.v1_16.*;
 import net.earthcomputer.multiconnect.protocols.v1_17.Protocol_1_17;
 import net.earthcomputer.multiconnect.protocols.v1_17.Protocol_1_17_1;
 import net.earthcomputer.multiconnect.protocols.v1_18.Protocol_1_18;
@@ -56,7 +48,7 @@ public class ProtocolRegistry {
     }
 
 
-    private static void register(int version, AbstractProtocol protocol) {
+    public static void register(int version, AbstractProtocol protocol) {
         protocols.put(version, protocol);
     }
 

--- a/src/main/resources/assets/multiconnect/lang/en_us.json
+++ b/src/main/resources/assets/multiconnect/lang/en_us.json
@@ -1,6 +1,8 @@
 {
   "multiconnect.betaWarning.line1": "%s is currently in beta support by multiconnect.",
   "multiconnect.betaWarning.line2": "Expect bugs, but report any you find to the issue tracker!",
+  "multiconnect.extensionWarning.line1": "%s support is implemented with a multiconnect extension.",
+  "multiconnect.extensionWarning.line2": "If you have any issues, report them to the extension's bug tracker.",
   "multiconnect.changeForcedProtocol": "Version",
   "multiconnect.config.allowOldUnsignedChat": "Insecure Messages",
   "multiconnect.config.allowOldUnsignedChat.tooltip": "Allows through insecure chat messages from 1.19.0 servers or older",

--- a/via-translator/src/main/java/net/earthcomputer/multiconnect/impl/via/ViaMulticonnectTranslator.java
+++ b/via-translator/src/main/java/net/earthcomputer/multiconnect/impl/via/ViaMulticonnectTranslator.java
@@ -34,7 +34,7 @@ public class ViaMulticonnectTranslator implements IMulticonnectTranslator {
     private static final Logger LOGGER = LogUtils.getLogger();
     private static final AttributeKey<UserConnection> VIA_USER_CONNECTION_KEY = AttributeKey.valueOf("multiconnect.via_user_connection");
 
-    private IMulticonnectTranslatorApi api;
+    protected IMulticonnectTranslatorApi api;
 
     @Override
     public boolean isApplicableInEnvironment(IMulticonnectTranslatorApi api) {


### PR DESCRIPTION
This changes `ConnectionMode` to be something registerable instead of being a big enum. I did try to retain binary compatibility. This was done so that I could register new versions into multiconnect in order to support [ViaLegacy](https://github.com/RaphiMC/ViaLegacy) with an extension. To contribute to that end, I also made `ViaMulticonnectTranslator#api` `protected` so I don't need to use a Mixin in order to set it.